### PR TITLE
Fix haddock not building

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -164,7 +164,7 @@
 
               packages = self.lib.mkOpaque (mk "packages" // (if docsPath == null then {} else {
                 docs = mkDocumentation docsPath;
-              }) // {
+              }) // (if toHaddock == [] then {} else {
                 haddock = inputs.plutus.${system}.plutus.library.combine-haddock {
                   ghc = hn.compiler.ghc924;
                   hspkgs = builtins.map (x: prj.hsPkgs.${x}.components.library) toHaddock;
@@ -181,7 +181,7 @@
                     '';
                   };
                 };
-              });
+              }));
               checks = self.lib.mkOpaque (mk "checks" // {
                 inherit formatting linting;
               });


### PR DESCRIPTION
Fixes #15.

Reason for build failure: basically, plutus' haddock builder can not handle empty `hspkgs`, list of packages to build Haddock for.

Fix: if `toHaddock == []`, do not build haddock. This means that there will be no `packages.${system}.haddock` output for the default case:

```
> nix build templates/haskell#haddock
error: flake '...' does not provide attribute 'packages.x86_64-linux.haddock', 'legacyPackages.x86_64-linux.haddock' or 'haddock'
```