### PR TITLE
Fix pre-commit hook

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -144,7 +144,7 @@ in
         if test ! -e "$fp"
         then
           set -x
-          echo -e '#!/bin/sh\n\nformat check' > "$fp" \
+          echo -e '#!/bin/sh\n\n,format check' > "$fp" \
             && chmod +x "$fp"
           set +x
         fi

--- a/module.nix
+++ b/module.nix
@@ -137,13 +137,14 @@ in
         (inputs.self.lib.mkLinter inputs.nixpkgs.legacyPackages.${pkgs.system})
       ];
       shellHook = ''
-        set -x
-        if test ! -e .git/hooks/pre-commit
+        fp=$(git rev-parse --git-path hooks)/pre-commit
+        if test ! -e "$fp"
         then
-          echo -e '#!/bin/sh\n\n,format check' > .git/hooks/pre-commit \
-            && chmod +x .git/hooks/pre-commit
+          set -x
+          echo -e '#!/bin/sh\n\nformat check' > "$fp" \
+            && chmod +x "$fp"
+          set +x
         fi
-        set +x
       '';
     };
   };


### PR DESCRIPTION
The git pre-commit hook had a typo "," inside.

Here I:
 - fix the typo
 - calculate the git hooks path (can be different for bare repositories and git worktrees)
 - move `set -x` inside if statement (why not?)